### PR TITLE
chore: remove unused scheme variant

### DIFF
--- a/src/location.rs
+++ b/src/location.rs
@@ -24,12 +24,6 @@ pub struct Itinerary {
 }
 
 impl Itinerary {
-    /// Elders will aggregate a group sig before
-    /// they all all send one copy of it each to dst.
-    pub fn aggregate_at_src(&self) -> bool {
-        matches!(self.aggregation, Aggregation::AtSource)
-    }
-
     /// Elders will send their signed message, which
     /// recipients aggregate.
     pub fn aggregate_at_dst(&self) -> bool {
@@ -52,9 +46,6 @@ impl Itinerary {
 pub enum Aggregation {
     /// No aggregation is made, eg. when the payload contains full authority.
     None,
-    /// Elders will aggregate a group sig before
-    /// they all all send one copy of it each to dst.
-    AtSource,
     /// Elders will send their signed message, which
     /// recipients aggregate.
     AtDestination,


### PR DESCRIPTION
Accumulation at source was removed at sn_routing and replaced with all out acc at dst.
Since we don't use it anywhere else we can safely remove it.