### PR TITLE
chore: remove unused code

### DIFF
--- a/src/client/blob.rs
+++ b/src/client/blob.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{AuthorisationKind, CmdError, DataAuthKind, Error, QueryResponse};
+use super::{CmdError, Error, QueryResponse};
 use serde::{Deserialize, Serialize};
 use sn_data_types::{Blob, BlobAddress, PublicKey};
 use std::fmt;
@@ -46,15 +46,6 @@ impl BlobRead {
         QueryResponse::GetBlob(Err(error))
     }
 
-    /// Returns the type of authorisation needed for the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        use BlobRead::*;
-        match self {
-            Get(BlobAddress::Public(_)) => AuthorisationKind::Data(DataAuthKind::PublicRead),
-            Get(BlobAddress::Private(_)) => AuthorisationKind::Data(DataAuthKind::PrivateRead),
-        }
-    }
-
     /// Returns the address of the destination for `request`.
     pub fn dst_address(&self) -> XorName {
         use BlobRead::*;
@@ -69,11 +60,6 @@ impl BlobWrite {
     /// Request variant.
     pub fn error(&self, error: Error) -> CmdError {
         CmdError::Data(error)
-    }
-
-    /// Returns the type of authorisation needed for the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        AuthorisationKind::Data(DataAuthKind::Write)
     }
 
     /// Returns the address of the destination for `request`.

--- a/src/client/cmd.rs
+++ b/src/client/cmd.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{data::DataCmd, transfer::TransferCmd, AuthorisationKind};
+use super::{data::DataCmd, transfer::TransferCmd};
 use serde::{Deserialize, Serialize};
 use sn_data_types::TransferAgreementProof;
 use xor_name::XorName;
@@ -28,15 +28,6 @@ pub enum Cmd {
 }
 
 impl Cmd {
-    /// Returns the type of authorisation needed for the cuest.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        use Cmd::*;
-        match self {
-            Data { cmd, .. } => cmd.authorisation_kind(),
-            Transfer(c) => c.authorisation_kind(),
-        }
-    }
-
     /// Returns the address of the destination for `cuest`.
     pub fn dst_address(&self) -> XorName {
         use Cmd::*;

--- a/src/client/data.rs
+++ b/src/client/data.rs
@@ -12,7 +12,7 @@ use super::{
     map::{MapRead, MapWrite},
     register::{RegisterRead, RegisterWrite},
     sequence::{SequenceRead, SequenceWrite},
-    AuthorisationKind, CmdError, Error, QueryResponse,
+    CmdError, Error, QueryResponse,
 };
 use sn_data_types::PublicKey;
 use xor_name::XorName;
@@ -44,16 +44,6 @@ impl DataCmd {
             Map(c) => c.error(error),
             Sequence(c) => c.error(error),
             Register(c) => c.error(error),
-        }
-    }
-    /// Returns the type of authorisation needed for the cuest.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        use DataCmd::*;
-        match self {
-            Blob(c) => c.authorisation_kind(),
-            Map(c) => c.authorisation_kind(),
-            Sequence(c) => c.authorisation_kind(),
-            Register(c) => c.authorisation_kind(),
         }
     }
 
@@ -115,17 +105,6 @@ impl DataQuery {
             Map(q) => q.error(error),
             Sequence(q) => q.error(error),
             Register(q) => q.error(error),
-        }
-    }
-
-    /// Returns the type of authorisation needed for the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        use DataQuery::*;
-        match self {
-            Blob(q) => q.authorisation_kind(),
-            Map(q) => q.authorisation_kind(),
-            Sequence(q) => q.authorisation_kind(),
-            Register(q) => q.authorisation_kind(),
         }
     }
 

--- a/src/client/map.rs
+++ b/src/client/map.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{AuthorisationKind, CmdError, DataAuthKind, Error, QueryResponse};
+use super::{CmdError, Error, QueryResponse};
 use sn_data_types::{
     Map, MapAddress as Address, MapEntryActions as Changes, MapPermissionSet as PermissionSet,
     PublicKey,
@@ -106,22 +106,6 @@ impl MapRead {
         }
     }
 
-    /// Returns the type of authorisation needed for the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        use MapRead::*;
-        match *self {
-            Get(_)
-            | GetValue { .. }
-            | GetShell(_)
-            | GetVersion(_)
-            | ListEntries(_)
-            | ListKeys(_)
-            | ListValues(_)
-            | ListPermissions(_)
-            | ListUserPermissions { .. } => AuthorisationKind::Data(DataAuthKind::PrivateRead),
-        }
-    }
-
     /// Returns the address of the destination for request.
     pub fn dst_address(&self) -> XorName {
         use MapRead::*;
@@ -165,11 +149,6 @@ impl MapWrite {
     /// Request variant.
     pub fn error(&self, error: Error) -> CmdError {
         CmdError::Data(error)
-    }
-
-    /// Returns the type of authorisation needed for the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        AuthorisationKind::Data(DataAuthKind::Write)
     }
 
     /// Returns the address of the destination for request.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -95,8 +95,6 @@ pub enum Message {
         cmd: Cmd,
         /// Message ID.
         id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
     /// Queries is a read-only operation.
     Query {
@@ -104,8 +102,6 @@ pub enum Message {
         query: Query,
         /// Message ID.
         id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
     /// An Event is a fact about something that happened.
     Event {
@@ -115,8 +111,6 @@ pub enum Message {
         id: MessageId,
         /// ID of causing cmd.
         correlation_id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
     /// The response to a query, containing the query result.
     QueryResponse {
@@ -126,8 +120,6 @@ pub enum Message {
         id: MessageId,
         /// ID of causing query.
         correlation_id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
     /// Cmd error.
     CmdError {
@@ -137,8 +129,6 @@ pub enum Message {
         id: MessageId,
         /// ID of causing cmd.
         correlation_id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
     /// Cmds only sent internally in the network.
     NodeCmd {
@@ -146,8 +136,6 @@ pub enum Message {
         cmd: NodeCmd,
         /// Message ID.
         id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
     /// An error of a NodeCmd.
     NodeCmdError {
@@ -157,8 +145,6 @@ pub enum Message {
         id: MessageId,
         /// ID of causing cmd.
         correlation_id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
     /// Events only sent internally in the network.
     NodeEvent {
@@ -168,8 +154,6 @@ pub enum Message {
         id: MessageId,
         /// ID of causing cmd.
         correlation_id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
     /// Queries is a read-only operation.
     NodeQuery {
@@ -177,8 +161,6 @@ pub enum Message {
         query: NodeQuery,
         /// Message ID.
         id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
     /// The response to a query, containing the query result.
     NodeQueryResponse {
@@ -188,8 +170,6 @@ pub enum Message {
         id: MessageId,
         /// ID of causing query.
         correlation_id: MessageId,
-        /// Target section's current PublicKey
-        target_section_pk: Option<PublicKey>,
     },
 }
 
@@ -207,42 +187,6 @@ impl Message {
             | Self::NodeQuery { id, .. }
             | Self::NodeCmdError { id, .. }
             | Self::NodeQueryResponse { id, .. } => *id,
-        }
-    }
-
-    /// Gets the message's expected section PublicKey.
-    pub fn target_section_pk(&self) -> Option<PublicKey> {
-        match self {
-            Self::Cmd {
-                target_section_pk, ..
-            }
-            | Self::Query {
-                target_section_pk, ..
-            }
-            | Self::Event {
-                target_section_pk, ..
-            }
-            | Self::QueryResponse {
-                target_section_pk, ..
-            }
-            | Self::CmdError {
-                target_section_pk, ..
-            }
-            | Self::NodeCmd {
-                target_section_pk, ..
-            }
-            | Self::NodeEvent {
-                target_section_pk, ..
-            }
-            | Self::NodeQuery {
-                target_section_pk, ..
-            }
-            | Self::NodeCmdError {
-                target_section_pk, ..
-            }
-            | Self::NodeQueryResponse {
-                target_section_pk, ..
-            } => *target_section_pk,
         }
     }
 }
@@ -572,7 +516,6 @@ mod tests {
         let message = Message::Query {
             query: Query::Transfer(TransferQuery::GetBalance(pk)),
             id,
-            target_section_pk: None,
         };
 
         // test msgpack serialization

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -251,8 +251,6 @@ impl Message {
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Serialize, Deserialize)]
 pub enum CmdError {
     ///
-    Auth(Error), // temporary, while Authenticator is not handling this
-    ///
     Data(Error), // DataError enum for better differentiation?
     ///
     Transfer(TransferError),
@@ -356,48 +354,6 @@ pub enum QueryResponse {
     GetHistory(Result<ActorHistory>),
     /// Get Store Cost.
     GetStoreCost(Result<Token>),
-}
-
-/// The kind of authorisation needed for a request.
-pub enum AuthorisationKind {
-    /// Authorisation for data requests.
-    Data(DataAuthKind),
-    /// Authorisation for token requests.
-    Token(TokenAuthKind),
-    /// Miscellaneous authorisation kinds.
-    /// NB: Not very well categorized yet
-    Misc(MiscAuthKind),
-    /// When none required.
-    None,
-}
-
-/// Authorisation for data requests.
-pub enum DataAuthKind {
-    /// Read of public data.
-    PublicRead,
-    /// Read of private data.
-    PrivateRead,
-    /// Write of data/metadata.
-    Write,
-}
-
-/// Authorisation for token requests.
-pub enum TokenAuthKind {
-    /// Request to get key balance.
-    ReadBalance,
-    /// Request to get key transfer history.
-    ReadHistory,
-    /// Request to transfer tokens from key.
-    Transfer,
-}
-
-/// Miscellaneous authorisation kinds.
-/// NB: Not very well categorized yet
-pub enum MiscAuthKind {
-    /// Request to manage app keys.
-    ManageAppKeys,
-    /// Request to mutate and transfer tokens from key.
-    WriteAndTransfer,
 }
 
 /// Error type for an attempted conversion from `QueryResponse` to a type implementing

--- a/src/client/network.rs
+++ b/src/client/network.rs
@@ -93,7 +93,7 @@ pub enum NodeEvent {
         proof: Signature,
     },
     /// Adults ack read/write of chunks as to convey responsivity.
-    ChunkOpHandled(Result<(), super::CmdError>),
+    ChunkWriteHandled(Result<(), super::CmdError>),
 }
 
 ///

--- a/src/client/query.rs
+++ b/src/client/query.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{data::DataQuery, transfer::TransferQuery, AuthorisationKind, Error, QueryResponse};
+use super::{data::DataQuery, transfer::TransferQuery, Error, QueryResponse};
 use serde::{Deserialize, Serialize};
 use xor_name::XorName;
 
@@ -22,15 +22,6 @@ pub enum Query {
 }
 
 impl Query {
-    /// Returns the type of authorisation needed for the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        use Query::*;
-        match self {
-            Data(q) => q.authorisation_kind(),
-            Transfer(q) => q.authorisation_kind(),
-        }
-    }
-
     /// Creates a Response containing an error, with the Response variant corresponding to the
     /// Request variant.
     pub fn error(&self, error: Error) -> QueryResponse {

--- a/src/client/register.rs
+++ b/src/client/register.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{AuthorisationKind, CmdError, DataAuthKind, Error, QueryResponse};
+use super::{CmdError, Error, QueryResponse};
 use serde::{Deserialize, Serialize};
 use sn_data_types::{
     register::{Address, Entry, Register, RegisterOp, User},
@@ -66,23 +66,6 @@ impl RegisterRead {
         }
     }
 
-    /// Returns the access categorisation of the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        match *self {
-            RegisterRead::Get(address)
-            | RegisterRead::Read(address)
-            | RegisterRead::GetPolicy(address)
-            | RegisterRead::GetUserPermissions { address, .. }
-            | RegisterRead::GetOwner(address) => {
-                if address.is_public() {
-                    AuthorisationKind::Data(DataAuthKind::PublicRead)
-                } else {
-                    AuthorisationKind::Data(DataAuthKind::PrivateRead)
-                }
-            }
-        }
-    }
-
     /// Returns the address of the destination for request.
     pub fn dst_address(&self) -> XorName {
         match self {
@@ -116,11 +99,6 @@ impl RegisterWrite {
     /// Request variant.
     pub fn error(&self, error: Error) -> CmdError {
         CmdError::Data(error)
-    }
-
-    /// Returns the access categorisation of the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        AuthorisationKind::Data(DataAuthKind::Write)
     }
 
     /// Returns the address of the destination for request.

--- a/src/client/sequence.rs
+++ b/src/client/sequence.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{AuthorisationKind, CmdError, DataAuthKind, Error, QueryResponse};
+use super::{CmdError, Error, QueryResponse};
 use serde::{Deserialize, Serialize};
 use sn_data_types::{
     PublicKey, Sequence, SequenceAddress as Address, SequenceEntry as Entry,
@@ -82,25 +82,6 @@ impl SequenceRead {
         }
     }
 
-    /// Returns the access categorisation of the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        use SequenceRead::*;
-        match *self {
-            Get(address)
-            | GetRange { address, .. }
-            | GetLastEntry(address)
-            | GetPublicPolicy(address)
-            | GetPrivatePolicy(address)
-            | GetUserPermissions { address, .. } => {
-                if address.is_public() {
-                    AuthorisationKind::Data(DataAuthKind::PublicRead)
-                } else {
-                    AuthorisationKind::Data(DataAuthKind::PrivateRead)
-                }
-            }
-        }
-    }
-
     /// Returns the address of the destination for request.
     pub fn dst_address(&self) -> XorName {
         use SequenceRead::*;
@@ -138,11 +119,6 @@ impl SequenceWrite {
     /// Request variant.
     pub fn error(&self, error: Error) -> CmdError {
         CmdError::Data(error)
-    }
-
-    /// Returns the access categorisation of the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        AuthorisationKind::Data(DataAuthKind::Write)
     }
 
     /// Returns the address of the destination for request.

--- a/src/client/transfer.rs
+++ b/src/client/transfer.rs
@@ -7,9 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-use super::{
-    AuthorisationKind, CmdError, Error, MiscAuthKind, QueryResponse, TokenAuthKind, TransferError,
-};
+use super::{CmdError, Error, QueryResponse, TransferError};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "simulated-payouts")]
 use sn_data_types::Transfer;
@@ -67,17 +65,6 @@ impl TransferCmd {
         }
     }
 
-    /// Returns the type of authorisation needed for the request.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        use TransferCmd::*;
-        match self {
-            RegisterTransfer(_) => AuthorisationKind::None, // the proof has the authority within it
-            ValidateTransfer(_) => AuthorisationKind::Misc(MiscAuthKind::WriteAndTransfer),
-            #[cfg(feature = "simulated-payouts")]
-            SimulatePayout(_) => AuthorisationKind::None,
-        }
-    }
-
     /// Returns the address of the destination for `request`.
     pub fn dst_address(&self) -> XorName {
         use TransferCmd::*;
@@ -125,16 +112,6 @@ impl TransferQuery {
             GetBalance(_) => QueryResponse::GetBalance(Err(error)),
             GetHistory { .. } => QueryResponse::GetHistory(Err(error)),
             GetStoreCost { .. } => QueryResponse::GetStoreCost(Err(error)),
-        }
-    }
-
-    /// Returns the type of authorisation needed for the query.
-    pub fn authorisation_kind(&self) -> AuthorisationKind {
-        use TransferQuery::*;
-        match self {
-            GetBalance(_) => AuthorisationKind::Token(TokenAuthKind::ReadBalance), // current state
-            GetHistory { .. } => AuthorisationKind::Token(TokenAuthKind::ReadHistory), // history of incoming transfers
-            GetStoreCost { .. } => AuthorisationKind::None,                            // store cost
         }
     }
 


### PR DESCRIPTION
- The Auth part is an old remnant which is not used in any flow since refactor of Authority with sigs etc.
- Target section PK is handled in another way in the AE-branch, which is to be merged soon.