### PR TITLE
feat: enable to directly generate wiremsg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ mod msg_id;
 #[cfg(not(feature = "client-only"))]
 pub mod node;
 pub mod section_info;
-mod serialisation;
+pub mod serialisation;
 
 pub use self::{
     errors::{Error, Result},
@@ -82,6 +82,32 @@ impl MessageType {
                 dest_info,
                 src_section_pk,
             } => WireMsg::serialize_node_msg(
+                msg,
+                dest_info.dest,
+                dest_info.dest_section_pk,
+                *src_section_pk,
+            ),
+        }
+    }
+
+    pub fn to_wire_msg(&self) -> Result<WireMsg> {
+        match self {
+            Self::SectionInfo { msg, dest_info } => {
+                WireMsg::new_section_info_msg(msg, dest_info.dest, dest_info.dest_section_pk)
+            }
+            Self::Client { msg, dest_info } => {
+                WireMsg::new_client_msg(msg, dest_info.dest, dest_info.dest_section_pk)
+            }
+            #[cfg(not(feature = "client-only"))]
+            Self::Routing { msg, dest_info } => {
+                WireMsg::new_routing_msg(msg, dest_info.dest, dest_info.dest_section_pk)
+            }
+            #[cfg(not(feature = "client-only"))]
+            Self::Node {
+                msg,
+                dest_info,
+                src_section_pk,
+            } => WireMsg::new_node_msg(
                 msg,
                 dest_info.dest,
                 dest_info.dest_section_pk,

--- a/src/serialisation/wire_msg_header.rs
+++ b/src/serialisation/wire_msg_header.rs
@@ -24,14 +24,14 @@ const MESSAGING_PROTO_VERSION: u16 = 1u16;
 
 // Header to be serialisied at the front of the wire message.
 // This header contains the information needed to deserialize the payload.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct WireMsgHeader {
     msg_id: MessageId,
     header_size: u16,
     version: u16,
     kind: MessageKind,
-    dest: XorName,
-    dest_section_pk: PublicKey,
+    pub(crate) dest: XorName,
+    pub(crate) dest_section_pk: PublicKey,
     src_section_pk: Option<PublicKey>,
 }
 


### PR DESCRIPTION
this should enable easier updating of `dest` without havign to
reserialise the whole struct every time